### PR TITLE
Add Support for Admin Notes

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,7 @@
+{
+    "core": null,
+    "plugins": [
+        "https://downloads.wordpress.org/plugin/woocommerce.4.5.1.zip",
+        "."
+    ]
+}

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -38,6 +38,17 @@ class My_Great_Extension {
 
         // Load the Admin Notes from the WooCommerce Data Store
         $data_store = WC_Data_Store::load('admin-note');
+
+        // Check for existing notes that match our note name and content data.
+        //  This ensures we don't create a duplicate note.
+        $note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
+        foreach( (array) $note_ids as $note_id ) {
+            $note           = WC_Admin_Notes::get_note( $note_id );
+            $content_data   = $note->get_content_data();
+            if ( property_exists( $content_data, 'getting_started' ) ) {
+                return;
+            }
+        }
     }
 
     // We'll call this function when our extension deactivates to remove 

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -61,6 +61,13 @@ class My_Great_Extension {
 
         // Set our note's title.
         $note->set_title( 'Getting Started' );
+
+        // Set our note's content.
+        $note->set_content(
+            sprintf(
+                'Extension activated on %s.', $activated_time_formatted
+            )
+        );
     }
 
     // We'll call this function when our extension deactivates to remove 

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -91,6 +91,14 @@ class My_Great_Extension {
         // Set the image for the note.  This property renders as the src
         //   attribute for an img tag, so use a string here.
         $note->set_image( '' );
+
+
+        // Set the note name and source.  You should store your extension's
+        //   name (slug) in the source property of the note.  You can use
+        //   the name property of the note to support multiple sub-types of
+        //   notes.  This also gives you a handy way of namespacing your notes.
+        $note->set_source( 'inbox-note-example');
+        $note->set_name( self::NOTE_NAME );
     }
 
     // We'll call this function when our extension deactivates to remove 

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -110,6 +110,9 @@ class My_Great_Extension {
         $note->add_action(
             'learn_more', 'Learn More', 'https://example.com'
         );
+
+        // Save the note to lock in our changes.
+        $note->save();
     }
 
     // We'll call this function when our extension deactivates to remove 

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -68,6 +68,16 @@ class My_Great_Extension {
                 'Extension activated on %s.', $activated_time_formatted
             )
         );
+        
+        // In addition to content, notes also support structured content.
+        //  You can use this property to re-localize notes on the fly, but
+        //  that is just one use.  You can store other data here too.  This
+        //  is backed by a longtext column in the database.
+        $note->set_content_data( (object) array(
+            'getting_started'       => true,
+            'activated'             => $activated_time,
+            'activated_formatted'   => $activated_time_formatted
+        ) );
     }
 
     // We'll call this function when our extension deactivates to remove 

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -87,6 +87,10 @@ class My_Great_Extension {
         // Set the type of layout the note uses.  Supported layout types are:
         //   'banner', 'plain', 'thumbnail'
         $note->set_layout( 'plain' );
+
+        // Set the image for the note.  This property renders as the src
+        //   attribute for an img tag, so use a string here.
+        $note->set_image( '' );
     }
 
     // We'll call this function when our extension deactivates to remove 

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -118,7 +118,10 @@ class My_Great_Extension {
     // We'll call this function when our extension deactivates to remove 
     //  the welcome note our extension created.
     public static function remove_activity_panel_inbox_welcome_notes() {
-
+        if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes' ) ) {
+            return;
+        }
+        WC_Admin_Notes::delete_notes_with_name( self::NOTE_NAME );
     }
 
 }

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -49,6 +49,12 @@ class My_Great_Extension {
                 return;
             }
         }
+
+        // Our welcome note will include information about when the extension
+        //   was activated.  This is just for demonstration.  You might include
+        //   other logic here depending on what data your note should contain.
+        $activated_time = current_time( 'timestamp', 0);
+        $activated_time_formatted = date( 'F jS', $activated_time );
     }
 
     // We'll call this function when our extension deactivates to remove 

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -22,6 +22,18 @@ class My_Great_Extension {
     //   since we'll be referencing it in multiple places later.
     const NOTE_NAME = 'mge-activation-notice';
 
+    // We'll call this function to display a welcome note in the inbox
+    //  when the extension activates.
+    public static function add_activity_panel_inbox_welcome_note() {
+
+    }
+
+    // We'll call this function when our extension deactivates to remove 
+    //  the welcome note our extension created.
+    public static function remove_activity_panel_inbox_welcome_notes() {
+
+    }
+
 }
 
 /**

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -99,6 +99,17 @@ class My_Great_Extension {
         //   notes.  This also gives you a handy way of namespacing your notes.
         $note->set_source( 'inbox-note-example');
         $note->set_name( self::NOTE_NAME );
+
+        // Add action buttons to the note.  A note can support 0, 1, or 2 actions.
+        //   The first parameter is the action name, which can be used for event handling.
+        //   The second parameter renders as the label for the button.
+        //   The third parameter is an optional URL for actions that require navigation.
+        $note->add_action(
+            'settings', 'Open Settings', '?page=wc-settings&tab=general'
+        );
+        $note->add_action(
+            'learn_more', 'Learn More', 'https://example.com'
+        );
     }
 
     // We'll call this function when our extension deactivates to remove 

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -78,6 +78,11 @@ class My_Great_Extension {
             'activated'             => $activated_time,
             'activated_formatted'   => $activated_time_formatted
         ) );
+
+        // Set the type of the note.  Note types are defined as enum-style
+        // constants in the WC_Admin_Note class.  Available note types are:
+        //   error, warning, update, info, marketing
+        $note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
     }
 
     // We'll call this function when our extension deactivates to remove 

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -17,7 +17,11 @@ use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
 
 class My_Great_Extension {
-    
+
+    // Using a constant for our note name makes our code easier to maintain
+    //   since we'll be referencing it in multiple places later.
+    const NOTE_NAME = 'mge-activation-notice';
+
 }
 
 /**

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -83,6 +83,10 @@ class My_Great_Extension {
         // constants in the WC_Admin_Note class.  Available note types are:
         //   error, warning, update, info, marketing
         $note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+
+        // Set the type of layout the note uses.  Supported layout types are:
+        //   'banner', 'plain', 'thumbnail'
+        $note->set_layout( 'plain' );
     }
 
     // We'll call this function when our extension deactivates to remove 

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -36,6 +36,19 @@ class My_Great_Extension {
 
 }
 
+// Register the activation and deactivation hooks.
+//   We'll put our calls for note creation/deletion inside dedicated
+//   functions to accomodate additional activation/deactivation behavior.
+function my_great_extension_activate() {
+    My_Great_Extension::add_activity_panel_inbox_welcome_note();
+}
+register_activation_hook( __FILE__, 'my_great_extension_activate');
+
+function my_great_extension_deactivate() {
+    My_Great_Extension::remove_activity_panel_inbox_welcome_notes();
+}
+register_deactivation_hook( __FILE__, 'my_great_extension_deactivate');
+
 /**
  * Register the JS.
  */

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -1,6 +1,12 @@
 <?php
 /**
  * Plugin Name: admin-note-example
+ * Plugin URI: https://woocommerce.com/
+ * Description: An example extension demonstrating Admin Notes in WooCommerce.
+ * Author: Automattic
+ * Author URI: https://woocommerce.com/
+ * Text Domain: admin-note-example
+ * Version: 1.0.0
  *
  * @package WC_Admin
  */
@@ -10,35 +16,35 @@
  */
 function add_extension_register_script() {
 
-	if ( ! class_exists( 'Automattic\WooCommerce\Admin\Loader' ) || ! \Automattic\WooCommerce\Admin\Loader::is_admin_page() ) {
-		return;
-	}
+    if ( ! class_exists( 'Automattic\WooCommerce\Admin\Loader' ) || ! \Automattic\WooCommerce\Admin\Loader::is_admin_page() ) {
+        return;
+    }
 
-	$script_path       = '/build/index.js';
-	$script_asset_path = dirname( __FILE__ ) . '/build/index.asset.php';
-	$script_asset      = file_exists( $script_asset_path )
-		? require( $script_asset_path )
-		: array( 'dependencies' => array(), 'version' => filemtime( $script_path ) );
-	$script_url = plugins_url( $script_path, __FILE__ );
+    $script_path       = '/build/index.js';
+    $script_asset_path = dirname( __FILE__ ) . '/build/index.asset.php';
+    $script_asset      = file_exists( $script_asset_path )
+        ? require( $script_asset_path )
+        : array( 'dependencies' => array(), 'version' => filemtime( $script_path ) );
+    $script_url = plugins_url( $script_path, __FILE__ );
 
-	wp_register_script(
-		'admin-note-example',
-		$script_url,
-		$script_asset['dependencies'],
-		$script_asset['version'],
-		true
-	);
+    wp_register_script(
+        'admin-note-example',
+        $script_url,
+        $script_asset['dependencies'],
+        $script_asset['version'],
+        true
+    );
 
-	wp_register_style(
-		'admin-note-example',
-		plugins_url( '/build/style.css', __FILE__ ),
-		// Add any dependencies styles may have, such as wp-components.
-		array(),
-		filemtime( dirname( __FILE__ ) . '/build/style.css' )
-	);
+    wp_register_style(
+        'admin-note-example',
+        plugins_url( '/build/style.css', __FILE__ ),
+        // Add any dependencies styles may have, such as wp-components.
+        array(),
+        filemtime( dirname( __FILE__ ) . '/build/style.css' )
+    );
 
-	wp_enqueue_script( 'admin-note-example' );
-	wp_enqueue_style( 'admin-note-example' );
+    wp_enqueue_script( 'admin-note-example' );
+    wp_enqueue_style( 'admin-note-example' );
 }
 
 add_action( 'admin_enqueue_scripts', 'add_extension_register_script' );

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -11,6 +11,11 @@
  * @package WC_Admin
  */
 
+
+ // Import WC Admin Classes
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
+
 /**
  * Register the JS.
  */

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -13,8 +13,8 @@
 
 
  // Import WC Admin Classes
-use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
-use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\Notes;
 
 class My_Great_Extension {
 
@@ -25,9 +25,9 @@ class My_Great_Extension {
     // We'll call this function to display a welcome note in the inbox
     //  when the extension activates.
     public static function add_activity_panel_inbox_welcome_note() {
-        
+
         // Check for Admin Note support
-        if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes') ) {
+        if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes') ) {
             return;
         }
 
@@ -43,7 +43,7 @@ class My_Great_Extension {
         //  This ensures we don't create a duplicate note.
         $note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
         foreach( (array) $note_ids as $note_id ) {
-            $note           = WC_Admin_Notes::get_note( $note_id );
+            $note           = Notes::get_note( $note_id );
             $content_data   = $note->get_content_data();
             if ( property_exists( $content_data, 'getting_started' ) ) {
                 return;
@@ -56,8 +56,8 @@ class My_Great_Extension {
         $activated_time = current_time( 'timestamp', 0);
         $activated_time_formatted = date( 'F jS', $activated_time );
 
-        // Instantiate a new Admin_Note object
-        $note = new WC_Admin_Note();
+        // Instantiate a new Note object
+        $note = new Note();
 
         // Set our note's title.
         $note->set_title( 'Getting Started' );
@@ -68,7 +68,7 @@ class My_Great_Extension {
                 'Extension activated on %s.', $activated_time_formatted
             )
         );
-        
+
         // In addition to content, notes also support structured content.
         //  You can use this property to re-localize notes on the fly, but
         //  that is just one use.  You can store other data here too.  This
@@ -80,9 +80,9 @@ class My_Great_Extension {
         ) );
 
         // Set the type of the note.  Note types are defined as enum-style
-        // constants in the WC_Admin_Note class.  Available note types are:
+        // constants in the Note class.  Available note types are:
         //   error, warning, update, info, marketing
-        $note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+        $note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 
         // Set the type of layout the note uses.  Supported layout types are:
         //   'banner', 'plain', 'thumbnail'
@@ -115,13 +115,13 @@ class My_Great_Extension {
         $note->save();
     }
 
-    // We'll call this function when our extension deactivates to remove 
+    // We'll call this function when our extension deactivates to remove
     //  the welcome note our extension created.
     public static function remove_activity_panel_inbox_welcome_notes() {
-        if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes' ) ) {
+        if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
             return;
         }
-        WC_Admin_Notes::delete_notes_with_name( self::NOTE_NAME );
+        Notes::delete_notes_with_name( self::NOTE_NAME );
     }
 
 }

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -16,6 +16,10 @@
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
 
+class My_Great_Extension {
+    
+}
+
 /**
  * Register the JS.
  */

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -25,7 +25,19 @@ class My_Great_Extension {
     // We'll call this function to display a welcome note in the inbox
     //  when the extension activates.
     public static function add_activity_panel_inbox_welcome_note() {
+        
+        // Check for Admin Note support
+        if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes') ) {
+            return;
+        }
 
+        // Make sure the WooCommerce Data Store is available
+        if ( ! class_exists( 'WC_Data_Store' ) ) {
+            return;
+        }
+
+        // Load the Admin Notes from the WooCommerce Data Store
+        $data_store = WC_Data_Store::load('admin-note');
     }
 
     // We'll call this function when our extension deactivates to remove 

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -58,6 +58,9 @@ class My_Great_Extension {
 
         // Instantiate a new Admin_Note object
         $note = new WC_Admin_Note();
+
+        // Set our note's title.
+        $note->set_title( 'Getting Started' );
     }
 
     // We'll call this function when our extension deactivates to remove 

--- a/admin-note-example.php
+++ b/admin-note-example.php
@@ -55,6 +55,9 @@ class My_Great_Extension {
         //   other logic here depending on what data your note should contain.
         $activated_time = current_time( 'timestamp', 0);
         $activated_time_formatted = date( 'F jS', $activated_time );
+
+        // Instantiate a new Admin_Note object
+        $note = new WC_Admin_Note();
     }
 
     // We'll call this function when our extension deactivates to remove 


### PR DESCRIPTION
This Pull Requests adds commits demonstrating how to add support for Admin Notes to a simple extension that was created by the WooCommerce Extension Generator that comes with [`woocommerce-admin`](https://github.com/woocommerce/woocommerce).

You can browse through each of the commits in this Pull Request to see what we added in each step of our tutorial.